### PR TITLE
Fix/conditionalize data flow

### DIFF
--- a/gqn/data/dataset.py
+++ b/gqn/data/dataset.py
@@ -6,8 +6,9 @@ from .subset import Subset
 
 
 class Dataset():
-    def __init__(self, directory):
+    def __init__(self, directory, use_original_images):
         self.directory = directory
+        self.use_original_images = use_original_images
         self.current_subset_index = 0
         self.subset_filenames = []
         files = os.listdir(os.path.join(self.directory, "images"))
@@ -32,8 +33,11 @@ class Dataset():
         images_npy_path = os.path.join(self.directory, "images", filename)
         viewpoints_npy_path = os.path.join(self.directory, "viewpoints",
                                            filename)
-        original_images_npy_path = os.path.join(self.directory, "original_images", filename)
-        subset = Subset(images_npy_path, viewpoints_npy_path, original_images_npy_path)
+        if self.use_original_images:
+            original_images_npy_path = os.path.join(self.directory, "original_images", filename)
+            subset = Subset(images_npy_path, viewpoints_npy_path, original_images_npy_path)
+        else:
+            subset = Subset(images_npy_path, viewpoints_npy_path)
         return subset
 
     def __len__(self):

--- a/gqn/data/subset.py
+++ b/gqn/data/subset.py
@@ -3,14 +3,19 @@ import numpy as np
 
 
 class Subset():
-    def __init__(self, image_npy_path, viewpoints_npy_path, original_images_npy_path):
+    def __init__(self, image_npy_path, viewpoints_npy_path, original_images_npy_path=""):
         self.images = np.load(image_npy_path)
         self.viewpoints = np.load(viewpoints_npy_path)
-        self.original_images = np.load(original_images_npy_path)
+        self.use_original_images = not original_images_npy_path == ""
+        if self.use_original_images:
+            self.original_images = np.load(original_images_npy_path)
         assert self.images.shape[0] == self.viewpoints.shape[0]
 
     def __getitem__(self, indices):
-        return self.images[indices], self.viewpoints[indices], self.original_images[indices]
+        if self.use_original_images:
+            return self.images[indices], self.viewpoints[indices], self.original_images[indices]
+        else:
+            return self.images[indices], self.viewpoints[indices]
 
     def __len__(self):
         return self.images.shape[0]

--- a/train_with_original.py
+++ b/train_with_original.py
@@ -53,7 +53,7 @@ def main():
         cuda.get_device(args.gpu_device).use()
         xp = cupy
 
-    dataset = gqn.data.Dataset(args.dataset_directory)
+    dataset = gqn.data.Dataset(args.dataset_directory, use_original_images=False)
 
     hyperparams = HyperParameters()
     hyperparams.generator_share_core = args.generator_share_core
@@ -124,7 +124,7 @@ def main():
             for batch_index, data_indices in enumerate(iterator):
                 # shape: (batch, views, height, width, channels)
                 # range: [-1, 1]
-                images, viewpoints, _original_images = subset[data_indices]
+                images, viewpoints = subset[data_indices]
 
                 # (batch, views, height, width, channels) -> (batch, views, channels, height, width)
                 images = images.transpose((0, 1, 4, 2, 3)).astype(np.float32)


### PR DESCRIPTION
Evernoteにも書いたけど、１シーンあたりの画像数を増やしたらめっちゃメモリーアロケート失敗するんで、見てみたら使いもしないoriginal_imagesを毎度無駄に読み込んでたんでその修正。

修正内容としては、そのデータセット関連を扱ってるDatasetクラスとSubsetクラスを条件分岐でoriginal_imagesを読み込ませるかを分けさせた。

※実際のメモリーアロケート失敗してた理由はおそらく１シーンが使うことになる画像の量が増えたことでメモリーが圧迫されてる気がする。
バッチサイズ減らしたら割と動くようになった。